### PR TITLE
feat: support for RINEX3 from GNSS archive and Geonet

### DIFF
--- a/etc/getdata.conf
+++ b/etc/getdata.conf
@@ -148,24 +148,31 @@ RankCosineFactor     10
 <CompressionTypes>
    <Compression>
        name hatanaka
-       compress /usr/bin/rnx2crx -f [input] 
-       uncompress /usr/bin/crx2rnx -f [input]
+       compress ${RNX2CRX_EXE||/usr/bin/rnx2crx} -f [input] 
+       uncompress ${CRX2RNX_EXE||/usr/bin/crx2rnx} -f [input]
        presuffix .ddo
        postsuffix .ddd
    </Compression>
    <Compression>
        name compress
-       compress /usr/bin/compress -f [input] 
-       uncompress /usr/bin/uncompress -f [input] 
+       compress ${COMPRESS_EXE||/usr/bin/compress} -f [input] 
+       uncompress ${UNCOMPRESS_EXE||/usr/bin/uncompress} -f [input] 
        presuffix 
        postsuffix .Z
    </Compression>
    <Compression>
        name gzip
-       compress /bin/gzip -f -9 [input] 
-       uncompress /bin/gzip -f -d [input] 
+       compress ${GZIP_EXE||/bin/gzip} -f -9 [input] 
+       uncompress ${GZIP_EXE||/bin/gzip} -f -d [input] 
        presuffix 
        postsuffix .gz
+   </Compression>
+   <Compression>
+       name rinex3
+       compress ${COPYFILE_EXE||/bin/cp} [input] [ouput]
+       uncompress ${GFXRNX_EXE||/usr/bin/gfzrnx} -finp [input] -fout [output] -f -satsys GE -vo 2 -errlog /dev/null
+       presuffix .in
+       postsuffix .out
    </Compression>
 </CompressionTypes>
 
@@ -189,15 +196,15 @@ EOD
         <DAILY>
             name Daily RINEX file
             priority 2
-            filename [ssss][ddd]0.[yy]d.Z
-            compression hatanaka+compress
+            filename [ssss][ddd]0.[yy]d.gz
+            compression hatanaka+gzip
             path  rinex/daily/[yyyy]/[ddd]
         </DAILY>
         <HOURLY>
             name Hourly RINEX file
             priority 1
-            filename [ssss][ddd][h].[yy]d.Z
-            compression hatanaka+compress
+            filename [ssss][ddd][h].[yy]d.gz
+            compression hatanaka+gzip
             frequency hourly
             path  rinex/hourly/[yyyy]/[ddd]/[hh]
             retention 2 days
@@ -444,89 +451,47 @@ EOD
 
 <StationLists>
 
-# Note: stations dunt, ldrz, lytt, and ousd are publicly accessible owned by 
-# University of Otago and NIWA
-
-geonet=<<EOD
-     2406 ahti akto arta auck aukt avln bhst birf bluf
-     bnet bthl cast chti ckid clim clrr cmbl cncl cnst
-     corm dnvk dund durv frtn gisb gldb glok gnbk grng
-     gunr haas hamt hana hanm hast hikb hoki hold horn
-     kahu kaik kapt kara kawk kere koko koro ktia kuta
-     levn lexa leyl lkta look maha mahi maho mako mang
-     matw mavl mcnl meth ming mkno mnhr mqzg mrbl mtbl
-     mtjo mtpr mtqn nlsn nmai nply nrrd nrsw ohin okoh
-     optk oroa otak paek paki pali pari parw pawa pgkh
-     pgne pilk pkno pnui pora prtu ptoi puke pygr quar
-     rahi rakw raul raum rawi rdlv rgar rgaw rghd rghl
-     rghr rgka rgkw rgli rgmk rgmt rgon rgop rgre rgrr
-     rgta rgut rgwc rgwi rgwv ripa sctb sedd snst sutt
-     takp taup tauw tema ten2 tenn tgho tghr tgoh tgra
-     tgri tgtk tgwh thap tint tkar tkhl tory trav trng
-     trwh turi vexa vget vgfw vgkr vgmo vgmt vgng vgnt
-     vgob vgot vgpk vgtm vgtr vgts vgwh vgwn vgwt wahu
-     waim waka wang wark west wgtn wgtt whkt whng whvr
-     with wmat wpaw wpuk wrau wrpa yald
-EOD
-
-privatecors=<<EOD
-     esbr esc2 escm eskv esqt esrn estr
-     gsaa gsab gsal gsam gsay gsba gsbd gsbl gsbn gsbr
-     gsc1 gscc gsch gscr gsct gscv gsdr gsgr gsht gshw
-     gskk gsli gslw gslx gsmh gsnl gso0 gsom gsox gspk
-     gspm gspn gspo gspu gsqt gsra gsrl gsro gssb gsta
-     gsth gsti gstk gstw gsut gswa gswh gswi gswk gswr
-     ppcw ppk2 ppkm ppmk ppor pppk pprs ppsp ppwh
-     syas sycc sycm syet syfr syha syka sylh symm syoi
-     syox sypn sypr syqn syta sytm syts
-     vak2 vaka vale vasb vash vbrm vchr vdun vham vhn2
-     vhra vhvn vlee vmay vmcs vmka vmrt vnpe vnpl voto
-     vpct vpmr vpn2 vpoa vprk vpt2 vpuk vptn vrng vrot
-     vshf vtea vtek vtem vthm vtim vtok vtwa vwan vwhk
-     vwig vwk2 vwkn vwku vwmr vwpk vzqn vwm2
-EOD
-
-publiccors=<<EOD
-     dunt ldrz lytt ousd
-EOD
-
-rdmn=<<EOD
-    1094 1102 1103 1104 1107 1108 1109 1112 1115 1145
-    1147 1151 1152 1162 1165 1166 1168 1172 1173 1175
-    1181 1182 1185 1186 1189 1190 1192 1195 1196 1204
-    1210 1230 1233 1235 1236 1238 1258 1260 1273 1274
-    1279 1281 1295 1297 1305 1331 1344 1361 1384 1394
-    1432 1433 1436 1501 1502 2386 2389 2392 2393 3582
-    3584 3585 3607 3608 3624 3662 4001 4036 6701 6703
-    6704 6705 6706 6708 6709 6711 6712 6713 6714 6717
-    6719 6721 6722 6723 6724 6725 6726 6728 6729 6730
-    6731 6733 6734 6735 6736 6737 6738 6739 6740 6754
-    6757 6767 6769 6770 6776 6784 6786 6787 6788 6790
-    6791 6792 6793 6794 a00a a05e a071 a0yh a26y a2j7
-    a2l2 a2qg a33d a3q5 a3r9 a3ru a3t4 a3t8 a3uj a3uu
-    a3v8 a3vn a3wb a3wj a3y4 a41n a42f a44v a48q a49q
-    a4bq a4fk a4mf a4pg a4uh a54b a55j a55w a593 a598
-    a5af a5ck a5lc a5mc a5np a5pd a5t0 a5tj a61n a68v
-    a6fq a6gp a6ju a6lt a6m0 a6p7 a6q1 a6x8 a71t a71v
-    a7fm a7r1 a7w4 a7we a8f0 a8gb a8je a8n1 a8tx a93q
-    a93w a9fj a9fl a9fw a9mk a9mt aa2m aa8h aab0 aad3
-    aadg aaej aaey aaj0 aaj1 aaj4 aaja aaju aakq aaqy
-    aar7 aar8 aara aarc aaup aayd ac68 ac6k ac72 ac73
-    ac76 ac7g ac7m ac7w ac8p acc5 acgf acmy acqy acvh
-    acvn adq1 adtf adw0 adwd ae20 ae3w ae4q aeb3 aecd
-    aelf aemc aemr aevv af5n af68 afb7 afjy aftc afun
-    aglh ahm8 am7g ap5e ap5t ap60 b000 b001 b0pc b0pd
-    b0t9 b0tb b15j b19t b19w b1du b1ep b1hk b1lv b1p3
-    b1rg b1tf b1wa b2bh b2fq b2nb b2nl b2p3 b36j b39p
-    b3bd b3ju b42l b7tk b7v0 b8cy b8dp b8k9 b8km b8l1
-    b8wl b8wm b8wn b8wp b8wq b8wr b8wt b8wu b8wv b8ww
-    b8wx b8wy b8x0 b8x1 b8x3 b8x4 b8x5 b8x6 b8x8 b8xb
-    b8xc b8xd b8xe b8xf b8xg b8xh b8xj b8xl b8xm b8xn
-    b8xp b8xq b8xr b8xt b8xu b8xv b8y2 b8y3 b9f3 b9fb
-    b9fc bc7h bd87 bd89 bugk cajp ddau df68 dffl dn4j
-    drlx ec0t eejg ej0c ejty er3b ewwl gds2 mul2 
-    6731 b39y exff exfg exfh exfj exfk exfl exfm exfn
-    exfp exfq exfr exft exfv exfw exfx exfy 
+positionzpp=<<EOD
+auck
+bluf
+chat
+chti
+corm
+dnvk
+dund
+gisb
+gldb
+haas
+hamt
+hast
+hikb
+hoki
+kaik
+ktia
+lexa
+lkta
+maho
+mast
+mavl
+meth
+mqzg
+mtjo
+nlsn
+nply
+ousd
+pygr
+taup
+trng
+vgmt
+waim
+wang
+wark
+west
+wgtn
+wgtt
+whkt
+whng
+wrpa
 EOD
 
 </StationLists>
@@ -646,12 +611,12 @@ EOD
     <DataCenter>
         priority 70
         Name LINZ-GNSSArchive-public
-        Uri https://public.archive.geodesy.linz.govt.nz
-        Stations @publiccors @geonet
+        Uri ${LINZ_GNSS_ARCHIVE_URL||https://public.archive.geodesy.linz.govt.nz}
+        Stations @positionzpp
         <Datafiles>
             <OBS>
                 <DAILY>
-                    path /rnx2_daily_30s/[yyyy]/[ddd]
+                    path rnx2_daily_30s/[yyyy]/[ddd]
                     filename [ssss][ddd]0.[yy]d.gz
                     compression hatanaka+gzip
                 </DAILY>
@@ -665,26 +630,23 @@ EOD
         </Datafiles>
     </DataCenter>
 
+    # RINEX3 files in archive
 
     <DataCenter>
         priority 70
-        Name LINZ-GNSSArchive
-        Type GNSSArchive
-        AuthKeyUri https://search.archive.geodesy.linz.govt.nz/v1/urlAuth
-        Uri https://private.archive.geodesy.linz.govt.nz
-        CredentialsFile ${GNSS_ARCHIVE_CREDENTIALS_FILE||/etc/bernese52/linz-gnss-archive-credentials.json}
-        Stations @privatecors
+        Name LINZ-GNSSArchive-RINEX3-public
+        Uri ${LINZ_GNSS_ARCHIVE_URL||https://public.archive.geodesy.linz.govt.nz}
+        Stations @positionzpp
         <Datafiles>
             <OBS>
                 <DAILY>
-                    path /rnx2_daily_30s/[yyyy]/[ddd]
-                    filename [ssss][ddd]0.[yy]d.gz
-                    compression hatanaka+gzip
+                    path rnx2_daily_30s/[yyyy]/[ddd]
+                    filename [ssss]00nzl_r_[yyyy][ddd]0000_01d_30s_mo.crx.gz
+                    compression rinex3+hatanaka+gzip
                 </DAILY>
                 <HOURLY>
-                    path /rnx2_hourly_30s/[yyyy]/[ddd]/[hh]
-                    filename [ssss][ddd][h].[yy]d.gz
-                    compression hatanaka+gzip
+                    filename [ssss]00nzl_r_[yyyy][ddd][hh]00_01h_30s_mo.crx.gz
+                    compression rinex3+hatanaka+gzip
                     latency 15 minutes
                 </HOURLY>
             </OBS>
@@ -696,7 +658,7 @@ EOD
         priority 60
         Name GeoNET-PNZ
         Uri https://data.geonet.org.nz
-        Stations @geonet
+        Stations @positionzpp
         <Datafiles>
             <OBS>
                 <DAILY>
@@ -713,55 +675,53 @@ EOD
             </OBS>
         </Datafiles>
     </DataCenter>
-    
+
+
     <DataCenter>
-        priority 30
-        Name UNAVCO
-        Uri ftp://anonymous:positionz@linz.govt.nz@data-out.unavco.org
-        Stations rob4 buri min0
-        Stations *
-        Notstations @geonet @privatecors
+        priority 60
+        Name GeoNET-PNZ
+        Uri https://data.geonet.org.nz
+        Stations @positionzpp
         <Datafiles>
             <OBS>
                 <DAILY>
-                    path /pub/rinex/obs/[yyyy]/[ddd]
-                    filename [ssss][ddd]0.[yy]d.Z
-                    compression hatanaka+compress                    
+                    path /gnss/rinex/[yyyy]/[ddd]
+                    filename [SSSS]00NZL_R_[yyyy][ddd]0000_01D_30S_MO.rnx.gz
+                    compression rinex3+gzip
                 </DAILY>
                 <HOURLY>
-                    path /pub/hourly/rinex/[yyyy]/[ddd]/[ssss]
-                    filename [ssss][ddd][h].[yy]d.Z
-                    compression hatanaka+compress                    
+                    filename [SSSS]00NZL_R_[yyyy][ddd][hh]00_01H_30S_MO.rnx.gz
+                    compression rinex3+gzip
                     latency 15 minutes
                 </HOURLY>
             </OBS>
         </Datafiles>
-    </DataCenter>
-    
+    </DataCenter>    
+   
     <DataCenter>
         priority 25
         Name SOPAC
         Uri ftp://anonymous:positionz@linz.govt.nz@garner.ucsd.edu
-        Stations mac1 mcm4 mobs pert yarr yar2 yarr nnor karr darr darw
-        Stations sunm cedu alic sydn str1 str2 tid2 tid1 tidb coco lae1
-        Stations fale aspa cas1 dav1 davr mkea tow2 jab1 noum rob4 buri
-        Stations min0
-        Stations *
-        NotStations @geonet @privatecors
+        # Stations mac1 mcm4 mobs pert yarr yar2 yarr nnor karr darr darw
+        # Stations sunm cedu alic sydn str1 str2 tid2 tid1 tidb coco lae1
+        # Stations fale aspa cas1 dav1 davr mkea tow2 jab1 noum rob4 buri
+        # Stations min0
+        # Stations *
+        # NotStations @geonet @privatecors
         <Datafiles>
-            <OBS>
-                # Obs commented out as not currently handling RINEX3 obs in Bernese
-                # <DAILY>
-                #     path /pub/rinex/[yyyy]/[ddd]
-                #     filename [SSSS]?????_R_[yyyy][ddd]0000_01D_30S_MO.crx.gz
-                #     compression hatanaka+gzip
-                # </DAILY>
-                # Hourly files currently still using RINEX2 filenames
-                # <HOURLY>
-                #     path /pub/nrtdata/[yyyy]/[ddd]/[hh]
-                #     latency 15 minutes
-                # </HOURLY>
-            </OBS>
+            # <OBS>
+            #     # Obs commented out as not currently handling RINEX3 obs in Bernese
+            #     # <DAILY>
+            #     #     path /pub/rinex/[yyyy]/[ddd]
+            #     #     filename [SSSS]?????_R_[yyyy][ddd]0000_01D_30S_MO.crx.gz
+            #     #     compression hatanaka+gzip
+            #     # </DAILY>
+            #     # Hourly files currently still using RINEX2 filenames
+            #     # <HOURLY>
+            #     #     path /pub/nrtdata/[yyyy]/[ddd]/[hh]
+            #     #     latency 15 minutes
+            #     # </HOURLY>
+            # </OBS>
             <ORB>
                 <FINAL>
                     path /products/[wwww]
@@ -834,19 +794,19 @@ EOD
         Name SOPAC2
         Uri ftp://anonymous:positionz@linz.govt.nz@garner.ucsd.edu
         <Datafiles>
-            <OBS>
-                <DAILY>
-                    path /pub/rinex/[yyyy]/[ddd]
-                    filename [ssss][ddd]0.[yy]d.Z
-                    compression hatanaka+compress                
-                </DAILY>
-                <HOURLY>
-                    path /pub/nrtdata/[yyyy]/[ddd]/[hh]
-                    filename [ssss][ddd][h].[yy]d.Z
-                    compression hatanaka+compress                
-                    latency 15 minutes
-                </HOURLY>
-            </OBS>
+            # <OBS>
+            #     <DAILY>
+            #         path /pub/rinex/[yyyy]/[ddd]
+            #         filename [ssss][ddd]0.[yy]d.Z
+            #         compression hatanaka+compress                
+            #     </DAILY>
+            #     <HOURLY>
+            #         path /pub/nrtdata/[yyyy]/[ddd]/[hh]
+            #         filename [ssss][ddd][h].[yy]d.Z
+            #         compression hatanaka+compress                
+            #         latency 15 minutes
+            #     </HOURLY>
+            # </OBS>
             <ORB>
                 <FINAL>
                     path /pub/products/[wwww]
@@ -1006,18 +966,18 @@ EOD
         Stations *
         NotStations @geonet @privatecors
         <Datafiles>
-            <OBS>
-                <DAILY>
-                    path /data/daily/[yyyy]/[ddd]/[yy]d
-                    filename [ssss][ddd]0.[yy]d.gz
-                    compression hatanaka+gzip
-                </DAILY>
-                <HOURLY>
-                    path /data/hourly/[yyyy]/[ddd]/[hh]
-                    filename [ssss][ddd][h].[yy]d.gz
-                    compression hatanaka+gzip
-                </HOURLY>
-            </OBS>
+            # <OBS>
+            #     <DAILY>
+            #         path /data/daily/[yyyy]/[ddd]/[yy]d
+            #         filename [ssss][ddd]0.[yy]d.gz
+            #         compression hatanaka+gzip
+            #     </DAILY>
+            #     <HOURLY>
+            #         path /data/hourly/[yyyy]/[ddd]/[hh]
+            #         filename [ssss][ddd][h].[yy]d.gz
+            #         compression hatanaka+gzip
+            #     </HOURLY>
+            # </OBS>
             <ORB>
                 <FINAL>
                     path /products/[wwww]
@@ -1176,18 +1136,18 @@ EOD
         Uri ftp://anonymous:positionz@linz.govt.nz@igs.ign.fr
         Notstations @geonet @privatecors
         <Datafiles>
-            <OBS>
-                <DAILY>
-                    path /pub/igs/data/[yyyy]/[ddd]
-                    filename [ssss][ddd]0.[yy]d.gz
-                    compression hatanaka+gzip
-                </DAILY>
-                <HOURLY>
-                    path /pub/igs/data/hourly/[yyyy]/[ddd]
-                    filename [ssss][ddd][h].[yy]d.gz
-                    compression hatanaka+gzip                    
-                </HOURLY>
-            </OBS>
+            # <OBS>
+            #     <DAILY>
+            #         path /pub/igs/data/[yyyy]/[ddd]
+            #         filename [ssss][ddd]0.[yy]d.gz
+            #         compression hatanaka+gzip
+            #     </DAILY>
+            #     <HOURLY>
+            #         path /pub/igs/data/hourly/[yyyy]/[ddd]
+            #         filename [ssss][ddd][h].[yy]d.gz
+            #         compression hatanaka+gzip                    
+            #     </HOURLY>
+            # </OBS>
             <ORB>
                 <FINAL>
                     path /pub/igs/products/[wwww]
@@ -1391,48 +1351,6 @@ EOD
         </VMF>
         </DataFiles>
     </DataCenter>
-
-    # Second GeoNET site: Separate instance to avoid non PositioNZ GNS stations 
-    # having higher priority than IGS stations
-    <DataCenter>
-        priority 10
-        Name GeoNET
-        Uri https://data.geonet.org.nz
-#        Uri ftp://anonymous:positionz@linz.govt.nz@ftp.geonet.org.nz
-        Stations @geonet
-        <Datafiles>
-            <OBS>
-                <DAILY>
-                    filename [ssss][ddd]0.[yy]o.gz
-                    path /gnss/rinex/[yyyy]/[ddd]
-                    compression gzip
-                </DAILY>
-                <HOURLY>
-                    filename [ssss][ddd][h].[yy]o.gz
-                    path /gnss/rinexhourly/[yyyy]/[ddd]
-                    compression gzip
-                    latency 15 minutes
-                </HOURLY>
-            </OBS>
-        </Datafiles>
-    </DataCenter>
- 
-#    <DataCenter>
-#        priority 25
-#        name PrivateCorsData
-#        Stations @privatecors
-#        Uri s3://${LINZ_GNSS_DATA_S3||linz-gnss-data-prod}/data/RINEX2
-#        <DataFiles>
-#            <OBS>
-#                <DAILY>
-#                    priority 2
-#                    path  [yyyy]/[ddd]
-#                    filename [ssss][DDD]0.[YY]d.gz
-#                    compression hatanaka+gzip
-#                </DAILY>
-#            </OBS>
-#      </Datafiles>
-#    </DataCenter>
 
     <DataCenter>
         priority 0

--- a/etc/getdata.conf
+++ b/etc/getdata.conf
@@ -679,7 +679,7 @@ EOD
 
     <DataCenter>
         priority 60
-        Name GeoNET-PNZ
+        Name GeoNET-PNZ-rinex3
         Uri https://data.geonet.org.nz
         Stations @positionzpp
         <Datafiles>


### PR DESCRIPTION
This updates the configuration of the PositioNZ-PP PCF to support retrieving RINEX3 files (and file names) from the LINZ GNSS archive and from the GeoNet HTTP data repository.   The RINEX3 data are converted to RINEX2 for the current processing strategy which expects RINEX2 data.

This also tidies up the getdata.conf configuration file to remove sources of RINEX obs files that are not relevant to PositioNZ-PP processing.