### PR TITLE
fix: removing FIXRINEX in readiness for 5.4

### DIFF
--- a/user/OPT/PNZ1REF/GETDATA.INP
+++ b/user/OPT/PNZ1REF/GETDATA.INP
@@ -249,7 +249,7 @@ MRGRINEX 1  "1"
 
 MSG_MRGRINEX 1  "Merge multiple RINEX files to make a single RINEX file for each station/session"
 
-FIXRINEX 1  "1"
+FIXRINEX 1  "0"
   ## widget = checkbox
   ## activeif = DNLDRS_F = 1 OR DNLDRS_A = 1 OR DNLDRS_C = 1
 


### PR DESCRIPTION
This removes the "FIXRINEX" option from the reference station load.  The 5.2 infrastructure ends up looking at PCV_COD.I08 for this - hardcoded into LINZ::BERN::BernUtil.pm. 

The modified sync process I want to put in place to support 5.4 is not enabling the I08 products, so simplest just to remove FIXRINEX and avoid the need for them.  This option is still present in current 5.4 image but actually does nothing - I will remove it from the GETDATA panel in the next 5.4 release.