### PR TITLE
feat: getdata S3 cache

### DIFF
--- a/etc/getdata.conf
+++ b/etc/getdata.conf
@@ -1458,7 +1458,7 @@ EOD
         priority 0
         Name Cache
         Stations *
-        Uri  file://${D}
+        Uri  ${GETDATA_CACHE_URL||file://${D}}
     </DataCenter>
 
 


### PR DESCRIPTION
This change instructs getdata to use an S3 cache.  Note that this will slightly slow down jobs with multiple RINEX files sharing the same reference data/orbit files as they will be collecting the common reference data from S3 rather than the local file system.  OTOH it will provide better resilience for product caches going down and significantly improve performance of multiple jobs using sharing common reference data.