### PR TITLE
Feat getdata cache

### DIFF
--- a/config/preload-getdata-config.json
+++ b/config/preload-getdata-config.json
@@ -1,0 +1,11 @@
+{
+    "products": [
+        {
+            "description": "Bernese rapid ionospheric products",
+            "type": "ION",
+            "subtype": "COD_RAP",
+            "start_days_ago": 3,
+            "end_days_ago": 1
+        }
+    ]
+}

--- a/config/preload-getdata-config.json
+++ b/config/preload-getdata-config.json
@@ -1,11 +1,90 @@
 {
     "products": [
         {
-            "description": "Bernese rapid ionospheric products",
+            "description": "PNZPP rapid processing products",
+            "type": "BIA",
+            "subtype": "COD_RAP",
+            "start_days_ago": 3,
+            "end_days_ago": 1
+        },
+        {
+            "description": "PNZPP rapid processing products",
+            "type": "CLK",
+            "subtype": "COD_RAP",
+            "start_days_ago": 3,
+            "end_days_ago": 1
+        },
+        {
+            "description": "PNZPP rapid processing products",
+            "type": "ERP",
+            "subtype": "COD_RAP",
+            "start_days_ago": 3,
+            "end_days_ago": 1
+        },
+        {
+            "description": "PNZPP rapid processing products",
             "type": "ION",
             "subtype": "COD_RAP",
             "start_days_ago": 3,
             "end_days_ago": 1
+        },
+        {
+            "description": "PNZPP rapid processing products",
+            "type": "ORB",
+            "subtype": "COD_RAP",
+            "start_days_ago": 3,
+            "end_days_ago": 1
+        },
+        {
+            "description": "PNZPP rapid processing products",
+            "type": "VMF",
+            "subtype": "VMF3",
+            "start_days_ago": 3,
+            "end_days_ago": 0
+        },
+
+
+        {
+            "description": "PNZPP final processing products",
+            "type": "BIA",
+            "subtype": "COD_FIN",
+            "start_days_ago": 20,
+            "end_days_ago": 12
+        },
+        {
+            "description": "PNZPP final processing products",
+            "type": "CLK",
+            "subtype": "COD_FIN",
+            "start_days_ago": 20,
+            "end_days_ago": 12
+        },
+        {
+            "description": "PNZPP final processing products",
+            "type": "ERP",
+            "subtype": "COD_FIN",
+            "start_days_ago": 20,
+            "end_days_ago": 12
+        },
+        {
+            "description": "PNZPP final processing products",
+            "type": "ION",
+            "subtype": "COD_FIN",
+            "start_days_ago": 20,
+            "end_days_ago": 12
+        },
+        {
+            "description": "PNZPP final processing products",
+            "type": "ORB",
+            "subtype": "COD_FIN",
+            "start_days_ago": 20,
+            "end_days_ago": 12
+        },
+        {
+            "description": "PNZPP final processing products",
+            "type": "VMF",
+            "subtype": "VMF3",
+            "start_days_ago": 20,
+            "end_days_ago": 0
         }
     ]
 }

--- a/datapool/config/getdata.conf
+++ b/datapool/config/getdata.conf
@@ -469,7 +469,7 @@ EOD
            filename VMF3_[yyyy][mm][dd].H[hh]
            compression none
            frequency 6hourly
-           buffer_after 6 hours
+           buffer_after 12 hours
            path /vmf/[yyyy]/[ddd]
        </VMF3>
     </VMF>

--- a/datapool/config/getdata.conf
+++ b/datapool/config/getdata.conf
@@ -461,6 +461,7 @@ EOD
            compression none
            frequency 6hourly
            path /vmf/[yyyy]/[ddd]
+           buffer_after 6 hours
        </VMF1>
        <VMF3>
            name  Vienna atmospheric mapping functions
@@ -468,6 +469,7 @@ EOD
            filename VMF3_[yyyy][mm][dd].H[hh]
            compression none
            frequency 6hourly
+           buffer_after 6 hours
            path /vmf/[yyyy]/[ddd]
        </VMF3>
     </VMF>

--- a/user/OPT/PNZ1REF/GETDATA.INP
+++ b/user/OPT/PNZ1REF/GETDATA.INP
@@ -402,10 +402,10 @@ DNLDNOW 1  "1"
 
 MSG_DNLDNOW 1  "Try to download now if data not in the cache"
 
-QUEUE 1  "0"
+FULLDAYS 1  "0"
   ## widget = checkbox
 
-MSG_QUEUE 1  "Queue the data for downloading if not available or downloaded"
+MSG_FULLDAYS 1  "Get products covering complete UTC days in the session"
 
 ! Wait/lock file
 LOCKFILE 0
@@ -454,8 +454,8 @@ DESCR_SYSERR 1  "Error message"
 #   (Queued jobs will only be downloaded if there is a queue manager           #
 #   job running.)                                                              #
 #                                                                              #
+#   Expand session to full days                           > % <                # FULLDAYS
 #   Try to download now if not in datapool                > % <                # DNLDNOW 
-#   Queue for download if not in datapool or downloaded   > % <                # QUEUE
 #                                                                              #
 # OUTPUT FILES                                                                 #
 #                                                                              #
@@ -473,7 +473,7 @@ DESCR_SYSERR 1  "Error message"
 # BEGIN_PANEL NO_CONDITION #####################################################
 # DOWNLOAD REFERENCE DATA - GETDATA 2: Orbit/ERP/OSB data                      # 
 #                                                                              #
-#   Orbit/ERP quality (+ = or better if available)   > %%%%%%% <               # ORBTYP
+#   Orbit/ERP quality (+ = or better if available)   > %%%%%%%%%%%%%% <        # ORBTYP
 #   Download orbits                                  > % <                     # DNLDORB
 #   Download earth rotation parameters               > % <                     # DNLDERP
 #   Download satellite 5 minute clock files          > % <                     # DNLDCLK
@@ -500,14 +500,14 @@ DESCR_SYSERR 1  "Error message"
 #   Download tropospheric models (.TRP)              > % <                     # DNLDTRP
 #                                                                              #
 #   Download ionospheric models (.ION)               > % <                     # DNLDION
-#       Ionosphere model quality                     > %%%%%%%% <              # IONTYP
+#       Ionosphere model quality                     > %%%%%%%%%%%%%% <        # IONTYP
 #       Merge ION files to a single file             > % <                     # MERGEION
-#       Name of merged ION file                      > %%%%%%%% <              # IONFILE
+#       Name of merged ION file                      > %%%%%%%%%%%%%% <        # IONFILE
 #                                                                              #
-#   Vienna Mapping Function version                  > %%%%%%% <               # VMFTYP
 #   Download VMF files                               > % <                     # DNLDVMF
+#       Vienna Mapping Function version              > %%%%%%%%%%%%%% <        # VMFTYP
 #       Merge VMF files to a single file             > % <                     # MERGEVMF
-#       Name of merged VMF file                      > %%%%%%%% <              # VMFFILE
+#       Name of merged VMF file                      > %%%%%%%%%%%%%% <        # VMFFILE
 #                                                                              #
 #   Include +/- session range in atmosphere products > % <                     # ATMPLUSM
 #                                                                              #

--- a/user/OPT/PNZ2NE2/GETDATA.INP
+++ b/user/OPT/PNZ2NE2/GETDATA.INP
@@ -186,7 +186,7 @@ MSG_OSBNAM 1  "Name for downloaded OSB files"
 ! -------------------------------------------------------------------------
 ! Plus/minus session range in atmosphere products
 ! ------------------
-ATMPLUSM 1  "1"
+ATMPLUSM 1  "0"
   ## widget = checkbox
 
 MSG_ATMPLUSM 1  "Include +/- session range in atmosphere products"

--- a/user/OPT/PNZ2NE2/GETDATA.INP
+++ b/user/OPT/PNZ2NE2/GETDATA.INP
@@ -49,7 +49,7 @@ DNLDORB 1  "1"
 MSG_DNLDORB 1  "Download orbit files"
 
 ORBTYP 1  "$(ORBTYP)"
-  ## widget=combobox; editable=false
+  ## widget=combobox; editable=true
   ## cards = BROADCAST ULTRA ULTRA+ RAPID RAPID+ FINAL COD_FIN COD_RAP CO3 IG3
 
 MSG_ORBTYP 1  "Orbit type, '+' = 'or better'"
@@ -115,7 +115,7 @@ TRPNAM 0
 MSG_TRPNAM 1  "Name for downloaded troposphere files"
 
 IONTYP 1  "$(IONTYP)"
-  ## widget=combobox; editable=false
+  ## widget=combobox; editable=true
   ## cards = PREDICT PREDICT+ RAPID RAPID+ COD_FIN COD_RAP
 
 MSG_IONTYP 1  "Ionosphere model quality, '+' = 'or better'"
@@ -142,7 +142,8 @@ MSG_IONNAM 1  "Name for downloaded ionosphere file(s)"
 ! Download VMF files
 ! ------------------
 VMFTYP 1  "VMF3"
-  ## widget=combobox; editable=false; cards = VMF1 VMF3
+  ## widget=combobox; editable=true
+  ## cards = VMF1 VMF3
 
 MSG_VMFTYP 1  "Vienna Mapping Function version"
 
@@ -167,8 +168,7 @@ MSG_VMFFILE 1  "Name of combined VMF files"
 ! Download daily Observation Specific Bias files
 ! ------------------
 OSBTYP 1  "$(OSBTYP)"
-  ## widget=combobox; editable=false
-  ## cards = RAPID RAPID+ COD_FIN COD_RAP CO3 IG3
+  ## widget=combobox; editable=true; cards = RAPID RAPID+ COD_FIN COD_RAP CO3 IG3
 
 MSG_OSBTYP 1  "OSB product quality, '+' = 'or better'"
 
@@ -284,7 +284,7 @@ DNLDRS_A 1  "0"
 MSG_DNLDRS_A 1  "Automatically select reference stations based on station coordinate"
 
 RSDTYPE 1  "DAILY"
-  ## widget=combobox; editable=false; cards = HOURLY HOURLY+ DAILY
+  ## widget=combobox; editable=true; cards = HOURLY HOURLY+ DAILY
   ## activeif = DNLDRS_0 = 0
 
 MSG_RSDTYPE 1  "RINEX file selection"
@@ -405,10 +405,10 @@ DNLDNOW 1  "1"
 
 MSG_DNLDNOW 1  "Try to download now if data not in the cache"
 
-QUEUE 1  "0"
+FULLDAYS 1  "1"
   ## widget = checkbox
 
-MSG_QUEUE 1  "Queue the data for downloading if not available or downloaded"
+MSG_FULLDAYS 1  "Get products covering complete UTC days in the session"
 
 ! Wait/lock file
 LOCKFILE 0
@@ -457,8 +457,8 @@ DESCR_SYSERR 1  "Error message"
 #   (Queued jobs will only be downloaded if there is a queue manager           #
 #   job running.)                                                              #
 #                                                                              #
+#   Expand session to full days                           > % <                # FULLDAYS
 #   Try to download now if not in datapool                > % <                # DNLDNOW 
-#   Queue for download if not in datapool or downloaded   > % <                # QUEUE
 #                                                                              #
 # OUTPUT FILES                                                                 #
 #                                                                              #
@@ -476,14 +476,14 @@ DESCR_SYSERR 1  "Error message"
 # BEGIN_PANEL NO_CONDITION #####################################################
 # DOWNLOAD REFERENCE DATA - GETDATA 2: Orbit/ERP/OSB data                      # 
 #                                                                              #
-#   Orbit/ERP quality (+ = or better if available)   > %%%%%%% <               # ORBTYP
+#   Orbit/ERP quality (+ = or better if available)   > %%%%%%%%%%%%%% <        # ORBTYP
 #   Download orbits                                  > % <                     # DNLDORB
 #   Download earth rotation parameters               > % <                     # DNLDERP
 #   Download satellite 5 minute clock files          > % <                     # DNLDCLK
 #   (clock files only available in RAPID and FINAL)                            #
 #                                                                              #
 #   Download daily Observation Specific Bias files                             #
-#      OSB product quality                           > %%%%%%% <               # OSBTYP
+#      OSB product quality                           > %%%%%%%%%%%%%% <        # OSBTYP
 #      Download daily OSB files                      > % <                     # DNLDOSB
 #                                                                              #
 #   Include +/- session range in orbit products      > % <                     # ORBPLUSM
@@ -503,14 +503,14 @@ DESCR_SYSERR 1  "Error message"
 #   Download tropospheric models (.TRP)              > % <                     # DNLDTRP
 #                                                                              #
 #   Download ionospheric models (.ION)               > % <                     # DNLDION
-#       Ionosphere model quality                     > %%%%%%%% <              # IONTYP
+#       Ionosphere model quality                     > %%%%%%%%%%%%%% <        # IONTYP
 #       Merge ION files to a single file             > % <                     # MERGEION
-#       Name of merged ION file                      > %%%%%%%% <              # IONFILE
+#       Name of merged ION file                      > %%%%%%%%%%%%%% <        # IONFILE
 #                                                                              #
-#   Vienna Mapping Function version                  > %%%%%%% <               # VMFTYP
 #   Download VMF files                               > % <                     # DNLDVMF
+#       Vienna Mapping Function version              > %%%%%%%%%%%%%% <        # VMFTYP
 #       Merge VMF files to a single file             > % <                     # MERGEVMF
-#       Name of merged VMF file                      > %%%%%%%% <              # VMFFILE
+#       Name of merged VMF file                      > %%%%%%%%%%%%%% <        # VMFFILE
 #                                                                              #
 #   Include +/- session range in atmosphere products > % <                     # ATMPLUSM
 #                                                                              #


### PR DESCRIPTION
This PR contains updates to improve PositioNZ-PP processing, especially the handling of 6 hourly VMF files in rapid processing.  

Note: This update depends on version 2.3.38 of the bernese54 docker image, so this PR should not be merged until the PositioNZ-PP service has been updated to support that.

There are two changes made here:
* using the new FULLDAYS option in the GETDATA.INP bernese input file.  This means that even if the job session only covers the first two hours of a UTC day, the GETDATA script will retrieve products to cover the whole UTC day.  Quite why this is required in GPSEST for VMF files I don't know, but experimentation shows that it is.
* Using the buffer_after option in getdata.conf for VMF files to expand the request period by 6 hours.  This is applied after expanding the request to the full UTC day.  The reason for this is that GETDATA assumes that a product file applies for the interval from its epoch to the epoch of the next file, eg a daily file provides data for the entire UTC day.  However VMF files are actually for a point in time at the epoch.  In order to provide data for the interval to the next epoch, the next epoch must also be retrieved and so that GPSEST can interpolate between them.  So to cover a full UTC day requires files for hours 0,6,12,18 of the UTC day and for hour 0 of the next UTC day.  getdata.conf has a new "buffer_after" parameter which is used to extend the request period so that it fetches this file as well.

Other changes are:
* removing the QUEUE parameter from the GETDATA user script.  This was used to just add a data request for missing data to a queue managed by the getdata cache.  This was an approach considered when the PositioNZ-PP was first built, but has never been used.  Instead the script just restarts at  a later time if some products are not yet available.
* changing the ATMPLUSM value in the PNZ2NE2/GETDATA.INP to 0, as there is no need to retrieve products for the preceding and following days.  This was being used to ensure that the required VMF products were available, but results in requiring more data than is necessary, and increasing the chance of failing with missing data.
* Adding a preload cache configuration which will retrieve products into the getdata cache a couple of times a day.  This is mainly to ensure that we get a full series of rapid files, but also should improve the efficiency of the processing service as it will spend less time getting orbital products.